### PR TITLE
Add :powerpack/render-hiccup configuration option for custom render

### DIFF
--- a/src/powerpack/app.clj
+++ b/src/powerpack/app.clj
@@ -73,6 +73,7 @@
 (s/def :powerpack/page-post-process-fns (s/coll-of ifn?))
 (s/def :powerpack/port number?)
 (s/def :powerpack/render-page ifn?)
+(s/def :powerpack/render-hiccup ifn?)
 (s/def :powerpack/resource-dirs (s/coll-of :file/directory))
 (s/def :powerpack/source-dirs (s/coll-of :file/directory))
 (s/def :asset-target/selector (s/coll-of (s/or :string string? :symbol symbol? :keyword keyword?)))
@@ -114,6 +115,7 @@
                 :powerpack/page-post-process-fns
                 :powerpack/port
                 :powerpack/resource-dirs
+                :powerpack/render-hiccup
                 :powerpack/source-dirs]))
 
 (def default-asset-targets

--- a/src/powerpack/web.clj
+++ b/src/powerpack/web.clj
@@ -96,7 +96,9 @@
                              location location)))))
 
 (defn prepare-response [context page response]
-  (let [content-type (get-content-type response)]
+  (let [content-type (get-content-type response)
+        render-html (or (-> context :powerpack/app :powerpack/render-hiccup)
+                        hiccup/render-html)]
     (cond
       (string? (:body response))
       response
@@ -112,7 +114,7 @@
                (hiccup/hiccup? (:body response)))
           (and (string? content-type)
                (re-find #"text/html" content-type)))
-      (update response :body (comp hiccup/render-html #(embellish-hiccup context page %)))
+      (update response :body (comp render-html #(embellish-hiccup context page %)))
 
       (or (= :json (:content-type response))
           (and (string? content-type)

--- a/test/powerpack/web_test.clj
+++ b/test/powerpack/web_test.clj
@@ -70,7 +70,7 @@
   (testing "Uses custom :powerpack/render-hiccup to render hiccup if it is provided"
     (is (= (sut/get-response-map
             {:uri "/"
-             :powerpack/app {:powerpack/render-hiccup #(str %)}}
+             :powerpack/app {:powerpack/render-hiccup str}}
             {}
             {:body [:body [:h1 "Custom renderer"]]})
            {:status 200

--- a/test/powerpack/web_test.clj
+++ b/test/powerpack/web_test.clj
@@ -67,6 +67,15 @@
            {:status 200
             :headers {"Content-Type" "text/html"}
             :body "<body><h1>Hello world</h1></body>"})))
+  (testing "Uses custom :powerpack/render-hiccup to render hiccup if it is provided"
+    (is (= (sut/get-response-map
+            {:uri "/"
+             :powerpack/app {:powerpack/render-hiccup #(str %)}}
+            {}
+            {:body [:body [:h1 "Custom renderer"]]})
+           {:status 200
+            :body "[:body [:h1 \"Custom renderer\"]]"
+            :headers {"Content-Type" "text/html"}})))
 
   (testing "Returns map with string body as html"
     (is (= (sut/get-response-map


### PR DESCRIPTION
Based on our discussion, add `:powerpack/render-hiccup` to support custom hiccup renderers like replicant. 

Use-case: Reuse existing replicant UI code / aliases from powerpack