### PR TITLE
fix(live-reload): Check if event's path exists before slurping

### DIFF
--- a/test/powerpack/live_reload_test.clj
+++ b/test/powerpack/live_reload_test.clj
@@ -17,3 +17,9 @@
   (is (false? (sut/config-changed?
                {:optimus/assets [{:public-dir "public" :paths [#".*\.png"]}]}
                {:optimus/assets [{:public-dir "public" :paths [#".*\.png"]}]}))))
+
+(deftest no-crash-if-path-absent  ; https://github.com/cjohansen/powerpack/issues/7
+  (is (nil? (sut/process-event {:kind :powerpack/edited-source
+                                :path "does-not-exist"}
+                               nil
+                               nil))))


### PR DESCRIPTION
On Linux, instead of a single :modify event we may first receive a `:delete` followed by a `:create`. When the watcher processes the first `:delete` event, the file doesn't exist, but it will come back for the next event.

Prevent the event processing crash in case the the event's path is missing.

Resolves #7
